### PR TITLE
Upkeep: Remove invalid Next.js option

### DIFF
--- a/packages/site/next.config.mjs
+++ b/packages/site/next.config.mjs
@@ -20,7 +20,6 @@ export default () => {
   writeJsonFileSync(DATA_PATH, getData())
 
   return {
-    cleanUrls: true,
     trailingSlash: false,
     eslint: {
       ignoreDuringBuilds: true


### PR DESCRIPTION
This PR removes the `cleanUrls` option.